### PR TITLE
Gera daglega vöktun þolnari

### DIFF
--- a/.github/workflows/uua-daily.yml
+++ b/.github/workflows/uua-daily.yml
@@ -1,4 +1,4 @@
-name: Dagleg UUA-vöktun
+name: Dagleg réttarvakt
 
 on:
   schedule:
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: uua-daily-monitoring
+  group: daily-legal-monitoring
   cancel-in-progress: false
 
 jobs:
@@ -33,6 +33,8 @@ jobs:
 
       - name: Sækja ný mál úr Samráðsgátt
         run: npm run collect:samrad
+        env:
+          SAMRAD_SOFT_FAIL: "1"
 
       - name: Vista keyrsluskýrslu
         uses: actions/upload-artifact@v4

--- a/scripts/collect-samrad.mjs
+++ b/scripts/collect-samrad.mjs
@@ -2,6 +2,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseSamradDetail, parseSamradFeed, validateSamrad } from "./samrad-lib.mjs";
+import { fetchWithRetry } from "./fetch-retry.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outputPath = resolve(root, "data/samrad.json");
@@ -17,7 +18,15 @@ async function saveJson(path, value) {
 }
 
 try {
-  const response = await fetch(feedUrl, { headers: { "user-agent": "Hrikalegur/0.1 (+https://hrikalegur.is)" }, signal: AbortSignal.timeout(30000) });
+  const requestOptions = {
+    headers: {
+      "user-agent": "Mozilla/5.0 (compatible; Hrikalegur/0.1; +https://hrikalegur.is)",
+      "accept": "application/rss+xml, application/xml, text/xml;q=0.9, */*;q=0.8",
+      "accept-language": "is,en;q=0.7"
+    },
+    signal: AbortSignal.timeout(30000)
+  };
+  const response = await fetchWithRetry(feedUrl, requestOptions);
   if (!response.ok) throw new Error(`Samráðsgátt svaraði með stöðukóða ${response.status}.`);
   const parsed = parseSamradFeed(await response.text());
   const initial = validateSamrad(parsed);
@@ -27,7 +36,7 @@ try {
     const batch = initial.accepted.slice(offset, offset + 6);
     const enriched = await Promise.all(batch.map(async (item) => {
       try {
-        const detailResponse = await fetch(item.url, { headers: { "user-agent": "Hrikalegur/0.1 (+https://hrikalegur.is)" }, signal: AbortSignal.timeout(20000) });
+        const detailResponse = await fetchWithRetry(item.url, { ...requestOptions, signal: AbortSignal.timeout(20000) }, { attempts: 2, delays: [1200] });
         if (!detailResponse.ok) throw new Error(`stöðukóði ${detailResponse.status}`);
         const detail = parseSamradDetail(await detailResponse.text(), item.url.match(/\/mal\/(\d+)/)?.[1]);
         return { ...item, ...detail, tags: `${item.tags} ${detail.tags}`.trim(), summary: detail.summary || item.summary };
@@ -53,7 +62,13 @@ try {
   });
   console.log(`Samráðsgátt: ${accepted.length} viðeigandi mál, ${newItems.length} ný, ${ignored.length} utan vöktunar.`);
 } catch (error) {
-  await saveJson(reportPath, { ok: false, source: "Samráðsgátt", sourceUrl: feedUrl, checkedAt: now, error: error.message });
-  console.error(`Vöktun Samráðsgáttar mistókst: ${error.message}`);
-  process.exitCode = 1;
+  const previousExists = await readFile(outputPath, "utf8").then(() => true).catch(() => false);
+  await saveJson(reportPath, { ok: false, source: "Samráðsgátt", sourceUrl: feedUrl, checkedAt: now, preservedPreviousData: previousExists, error: error.message });
+  const message = `Vöktun Samráðsgáttar mistókst: ${error.message}. ${previousExists ? "Síðustu gildu gögn voru varðveitt." : "Engin eldri gögn fundust."}`;
+  if (process.env.SAMRAD_SOFT_FAIL === "1" && previousExists) {
+    console.warn(message);
+  } else {
+    console.error(message);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/fetch-retry.mjs
+++ b/scripts/fetch-retry.mjs
@@ -1,0 +1,23 @@
+const retryableStatuses = new Set([403, 408, 425, 429]);
+
+export async function fetchWithRetry(url, options = {}, settings = {}) {
+  const attempts = settings.attempts ?? 3;
+  const delays = settings.delays ?? [1500, 4000];
+  const fetchImpl = settings.fetchImpl ?? fetch;
+  const sleep = settings.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  let lastError;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, options);
+      if (response.ok || (!retryableStatuses.has(response.status) && response.status < 500)) return response;
+      lastError = new Error(`stöðukóði ${response.status}`);
+      if (attempt === attempts - 1) return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts - 1) throw error;
+    }
+    await sleep(delays[Math.min(attempt, delays.length - 1)] ?? 0);
+  }
+  throw lastError;
+}

--- a/test/fetch-retry.test.mjs
+++ b/test/fetch-retry.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fetchWithRetry } from "../scripts/fetch-retry.mjs";
+
+test("endurprófar tímabundið 403-svar", async () => {
+  let calls = 0;
+  const response = await fetchWithRetry("https://example.test", {}, {
+    attempts: 3,
+    delays: [0, 0],
+    sleep: async () => {},
+    fetchImpl: async () => ({ ok: ++calls === 3, status: calls === 3 ? 200 : 403 })
+  });
+  assert.equal(response.status, 200);
+  assert.equal(calls, 3);
+});
+
+test("endurprófar ekki varanlegt 404-svar", async () => {
+  let calls = 0;
+  const response = await fetchWithRetry("https://example.test", {}, {
+    attempts: 3,
+    sleep: async () => {},
+    fetchImpl: async () => { calls += 1; return { ok: false, status: 404 }; }
+  });
+  assert.equal(response.status, 404);
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
Lagfærir bilun í daglegri keyrslu þegar Samráðsgátt svarar tímabundið með 403. Bætir við endurtilraunum, varðveitir síðustu gildu gögn, leyfir UUA-vöktun að halda áfram og endurnefnir verkflæðið í Dagleg réttarvakt. Tíu próf standast, þar á meðal hermd 403-villa.