### PR TITLE
Bæta við vöktun Stjórnarráðsins

### DIFF
--- a/.github/workflows/uua-daily.yml
+++ b/.github/workflows/uua-daily.yml
@@ -36,6 +36,11 @@ jobs:
         env:
           SAMRAD_SOFT_FAIL: "1"
 
+      - name: Sækja nýjar fréttir Stjórnarráðsins
+        run: npm run collect:stjornarrad
+        env:
+          STJORNARRAD_SOFT_FAIL: "1"
+
       - name: Vista keyrsluskýrslu
         uses: actions/upload-artifact@v4
         with:
@@ -50,14 +55,21 @@ jobs:
           path: data/samrad-report.json
           retention-days: 14
 
+      - name: Vista skýrslu Stjórnarráðsins
+        uses: actions/upload-artifact@v4
+        with:
+          name: stjornarrad-report-${{ github.run_number }}
+          path: data/stjornarrad-report.json
+          retention-days: 14
+
       - name: Birta aðeins ef málaskrá breyttist
         run: |
-          if git diff --quiet -- data/uua.json data/samrad.json; then
+          if git diff --quiet -- data/uua.json data/samrad.json data/stjornarrad.json; then
             echo "Engin ný eða breytt mál."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/uua.json data/samrad.json
+          git add data/uua.json data/samrad.json data/stjornarrad.json
           git commit -m "Uppfæra daglega réttarvakt"
           git push

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ Samráðssafnarinn les opinbera RSS-veitu Samráðsgáttarinnar, sem gáttin upp
 ```sh
 npm run collect:samrad
 ```
+
+## Stjórnarráðið
+
+Safnarinn les opinberan RSS-straum með fréttum frá öllum ráðuneytum og birtir aðeins fréttir sem falla að vöktuðum efnisorðum. Beinir fréttatenglar, titlar og dagsetningar eru sannreynd áður en færslur birtast. Stutta reifunin kemur úr opinberri lýsingu fréttarinnar og er merkt sem óyfirfarin. Eldri gögn eru varðveitt ef þjónustan bilar tímabundið.
+
+```sh
+npm run collect:stjornarrad
+```

--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ document.querySelector("#filter-toggle").addEventListener("click", (event) => {
 render();
 
 async function loadMonitoring() {
-  const sources = await Promise.all(["uua", "samrad"].map(async (name) => {
+  const sources = await Promise.all(["uua", "samrad", "stjornarrad"].map(async (name) => {
     try {
       const response = await fetch(`./data/${name}.json`, { cache: "no-store" });
       if (!response.ok) return null;

--- a/data/stjornarrad-report.json
+++ b/data/stjornarrad-report.json
@@ -1,0 +1,106 @@
+{
+  "ok": true,
+  "source": "Stjórnarráðið",
+  "sourceUrl": "https://www.stjornarradid.is/extensions/news/rss/Frettir-fra-ollum-raduneytum.rss",
+  "checkedAt": "2026-08-07T21:44:03.853Z",
+  "changed": false,
+  "counts": {
+    "received": 20,
+    "accepted": 3,
+    "stored": 3,
+    "new": 0,
+    "ignored": 17,
+    "duplicates": 0,
+    "rejected": 0
+  },
+  "newItems": [],
+  "ignored": [
+    {
+      "title": "Undirrituðu viljayfirlýsingu um að bæta stöðu hinsegin fólks á vinnumarkaði",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/07/Undirritudu-viljayfirlysingu-um-ad-baeta-stodu-hinsegin-folks-a-vinnumarkadi/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Ráðherra heimsótt öll lögregluembætti",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/07/Radherra-heimsott-oll-logregluembaetti/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Utanríkisráðherra fundaði með varnarmálaráðherra Belgíu",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/07/Utanrikisradherra-fundadi-med-varnarmalaradherra-Belgiu-/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Drengja- og stúlknalið Ascent Soccer frá Malaví heimsóttu utanríkisráðuneytið",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/07/Drengja-og-stulknalid-Ascent-Soccer-fra-Malavi-heimsottu-utanrikisraduneytid/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Tölustafir innleiddir í stað bókstafa",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/07/Tolustafir-innleiddir-i-stad-bokstafa/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Margrét Helga skipuð í embætti dómara við Héraðsdóm Norðurlands eystra",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/07/Margret-Helga-skipud-i-embaetti-domara-vid-Heradsdom-Nordurlands-eystra/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Auglýst eftir umsóknum um jarðræktarstyrki í garðyrkju",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/06/Auglyst-eftir-umsoknum-um-jardraektarstyrki-i-gardyrkju/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Þrettán umsækjendur um embætti forstjóra Stofnunar atvinnuveganna",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/06/Threttan-umsaekjendur-um-embaetti-forstjora-Stofnunar-atvinnuveganna/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Áhættumat fyrir þéttbýlið í Grindavík endurskoðað",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/06/Ahaettumat-fyrir-thettbylid-i-Grindavik-endurskodad/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Belgíski flugherinn sinnir loftrýmisgæslu á Íslandi",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/06/Belgiski-flugherinn-sinnir-loftrymisgaeslu-a-Islandi/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Opnað fyrir umsóknir til listamannalauna og í Sviðslistasjóð",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/06/Opnad-fyrir-umsoknir-til-listamannalauna-og-i-Svidslistasjod/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Ragnar Þór heimsótti Vestur-Íslendinga í Manitoba og Norður-Dakóta",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/05/Ragnar-Thor-heimsotti-Vestur-Islendinga-i-Manitoba-og-Nordur-Dakota/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Drög að frumvarpi um Stafræna heilsu til umsagnar",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/04/Drog-ad-frumvarpi-um-Stafraena-heilsu-til-umsagnar/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Ráðherra sat fjarfund um stöðuna í Ceuta",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/04/Radherra-sat-fjarfund-um-stoduna-i-Ceuta/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Dómsmálaráðherra skipar nýja bótanefnd",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/04/Domsmalaradherra-skipar-nyja-botanefnd/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Heilbrigðisþing 2026 haldið 26. nóvember – takið daginn frá",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/07/23/Heilbrigdisthing-2026-haldid-26.-november-takid-daginn-fra/",
+      "reason": "utan vaktaðra efnisorða"
+    },
+    {
+      "title": "Frumvarpsdrög um breyttan útivistartíma barna kynnt til samráðs",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/07/23/-Frumvarpsdrog-um-breyttan-utivistartima-barna-kynnt-til-samrads/",
+      "reason": "utan vaktaðra efnisorða"
+    }
+  ],
+  "duplicates": [],
+  "rejected": []
+}

--- a/data/stjornarrad.json
+++ b/data/stjornarrad.json
@@ -1,0 +1,43 @@
+{
+  "source": "Stjórnarráðið",
+  "sourceUrl": "https://www.stjornarradid.is/extensions/news/rss/Frettir-fra-ollum-raduneytum.rss",
+  "fetchedAt": "2026-08-07T21:43:42.593Z",
+  "items": [
+    {
+      "id": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/05/Aflaheimildir-til-strandveida-auknar-um-964-tonn/",
+      "category": "frett",
+      "type": "Frétt",
+      "source": "Stjórnarráðið",
+      "publishedAt": "2026-08-05T14:00:00.000Z",
+      "title": "Aflaheimildir til strandveiða auknar um 964 tonn",
+      "summary": "Innviðaráðherra hefur á ný aukið aflaheimildir til strandveiða á yfirstandandi strandveiðitímabili.",
+      "tags": "veiðar",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/05/Aflaheimildir-til-strandveida-auknar-um-964-tonn/",
+      "relevant": true
+    },
+    {
+      "id": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/07/28/Uthlutun-styrkja-Strandhreinsun-Islands-2026/",
+      "category": "frett",
+      "type": "Frétt",
+      "source": "Stjórnarráðið",
+      "publishedAt": "2026-07-28T09:05:00.000Z",
+      "title": "Úthlutun styrkja: Strandhreinsun Íslands 2026",
+      "summary": "Jóhann Páll Jóhannsson, umhverfis-, orku- og loftslagsráðherra, hefur úthlutað 18 styrkjum til verkefna sem felast í hreinsun á strandlengju Íslands á grundvelli tillögu Umhverfis- og orkustofnunar.",
+      "tags": "loftslagsmál",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/07/28/Uthlutun-styrkja-Strandhreinsun-Islands-2026/",
+      "relevant": true
+    },
+    {
+      "id": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/07/24/Frumvarpsdrog-um-innleidingu-a-CBAM-reglugerd-ESB-sett-i-Samradsgatt/",
+      "category": "frett",
+      "type": "Frétt",
+      "source": "Stjórnarráðið",
+      "publishedAt": "2026-07-24T11:19:00.000Z",
+      "title": "Frumvarpsdrög um innleiðingu á CBAM-reglugerð ESB sett í Samráðsgátt",
+      "summary": "Umhverfis-, orku- og loftslagsráðuneytið hefur birt í Samráðsgátt stjórnvalda frumvarp til innleiðingar á reglugerð Evrópuþingsins og ráðsins (ESB) 2023/956 frá 10. maí 2023 um að koma á fót aðlögunarkerfi við landamæri vegna…",
+      "tags": "loftslagsmál",
+      "url": "https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/07/24/Frumvarpsdrog-um-innleidingu-a-CBAM-reglugerd-ESB-sett-i-Samradsgatt/",
+      "relevant": true
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
             <button class="chip active" data-category="all" type="button">Allt</button>
             <button class="chip" data-category="urskurdur" type="button">Úrskurðir</button>
             <button class="chip" data-category="samrad" type="button">Samráð</button>
+            <button class="chip" data-category="frett" type="button">Fréttir</button>
             <button class="chip" data-category="loggjof" type="button">Löggjöf</button>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "collect:uua": "node scripts/collect-uua.mjs",
     "collect:samrad": "node scripts/collect-samrad.mjs",
+    "collect:stjornarrad": "node scripts/collect-stjornarrad.mjs",
     "test": "node --test"
   }
 }

--- a/scripts/collect-stjornarrad.mjs
+++ b/scripts/collect-stjornarrad.mjs
@@ -1,0 +1,53 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { fetchWithRetry } from "./fetch-retry.mjs";
+import { parseStjornarradFeed, validateStjornarrad } from "./stjornarrad-lib.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const outputPath = resolve(root, "data/stjornarrad.json");
+const reportPath = resolve(root, "data/stjornarrad-report.json");
+const feedUrl = process.env.STJORNARRAD_FEED_URL || "https://www.stjornarradid.is/extensions/news/rss/Frettir-fra-ollum-raduneytum.rss";
+const now = new Date().toISOString();
+
+async function saveJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.new`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(temporary, path);
+}
+
+try {
+  const response = await fetchWithRetry(feedUrl, {
+    headers: {
+      "user-agent": "Mozilla/5.0 (compatible; Hrikalegur/0.1; +https://hrikalegur.is)",
+      "accept": "application/rss+xml, application/xml, text/xml;q=0.9, */*;q=0.8",
+      "accept-language": "is,en;q=0.7"
+    },
+    signal: AbortSignal.timeout(30000)
+  });
+  if (!response.ok) throw new Error(`Stjórnarráðið svaraði með stöðukóða ${response.status}.`);
+  const parsed = parseStjornarradFeed(await response.text());
+  const { accepted, rejected, ignored, duplicates } = validateStjornarrad(parsed);
+  const previous = await readFile(outputPath, "utf8").then(JSON.parse).catch(() => null);
+  const previousItems = previous?.items || [];
+  const previousIds = new Set(previousItems.map((item) => item.id));
+  const newItems = accepted.filter((item) => !previousIds.has(item.id));
+  const currentIds = new Set(accepted.map((item) => item.id));
+  const storedItems = [...accepted, ...previousItems.filter((item) => !currentIds.has(item.id))]
+    .sort((a, b) => (b.publishedAt || "").localeCompare(a.publishedAt || ""));
+  const changed = !previous || JSON.stringify(previousItems) !== JSON.stringify(storedItems);
+  if (changed) await saveJson(outputPath, { source: "Stjórnarráðið", sourceUrl: feedUrl, fetchedAt: now, items: storedItems });
+  await saveJson(reportPath, {
+    ok: true, source: "Stjórnarráðið", sourceUrl: feedUrl, checkedAt: now, changed,
+    counts: { received: parsed.length, accepted: accepted.length, stored: storedItems.length, new: newItems.length, ignored: ignored.length, duplicates: duplicates.length, rejected: rejected.length },
+    newItems: newItems.map(({ id, title, url }) => ({ id, title, url })), ignored, duplicates, rejected
+  });
+  console.log(`Stjórnarráðið: ${accepted.length} viðeigandi fréttir, ${newItems.length} nýjar, ${ignored.length} utan vöktunar.`);
+} catch (error) {
+  const previousExists = await readFile(outputPath, "utf8").then(() => true).catch(() => false);
+  await saveJson(reportPath, { ok: false, source: "Stjórnarráðið", sourceUrl: feedUrl, checkedAt: now, preservedPreviousData: previousExists, error: error.message });
+  const message = `Vöktun Stjórnarráðsins mistókst: ${error.message}. ${previousExists ? "Síðustu gildu gögn voru varðveitt." : "Engin eldri gögn fundust."}`;
+  if (process.env.STJORNARRAD_SOFT_FAIL === "1" && previousExists) console.warn(message);
+  else { console.error(message); process.exitCode = 1; }
+}

--- a/scripts/stjornarrad-lib.mjs
+++ b/scripts/stjornarrad-lib.mjs
@@ -1,0 +1,63 @@
+import { extractKeywords, plainText, summarize } from "./uua-lib.mjs";
+
+function field(xml, tag) {
+  const safe = tag.replace(":", "\\:");
+  return xml.match(new RegExp(`<${safe}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${safe}>`, "i"))?.[1]?.replace(/^<!\[CDATA\[|\]\]>$/g, "").trim() || "";
+}
+
+export function parseStjornarradFeed(xml) {
+  if (!/<rss\b/i.test(xml) || !/<channel>/i.test(xml)) throw new Error("Svarið er ekki gildur RSS-straumur.");
+  return [...xml.matchAll(/<item(?:\s[^>]*)?>([\s\S]*?)<\/item>/gi)].map((match) => {
+    const item = match[1];
+    const title = plainText(field(item, "title"));
+    const url = plainText(field(item, "link"));
+    const description = field(item, "description");
+    const content = field(item, "lisalive:content") || description;
+    const published = plainText(field(item, "pubDate"));
+    const date = new Date(published);
+    const tags = extractKeywords(`${title} ${description} ${content}`);
+    return {
+      id: url,
+      category: "frett",
+      type: "Frétt",
+      source: "Stjórnarráðið",
+      publishedAt: Number.isNaN(date.valueOf()) ? "" : date.toISOString(),
+      title,
+      summary: summarize(description) || title,
+      tags,
+      url,
+      relevant: Boolean(tags)
+    };
+  });
+}
+
+export function validateStjornarrad(items) {
+  const accepted = [], rejected = [], ignored = [], duplicates = [], seen = new Set();
+  for (const item of items) {
+    if (!item.relevant) {
+      ignored.push({ title: item.title, url: item.url, reason: "utan vaktaðra efnisorða" });
+      continue;
+    }
+    const reasons = [];
+    if (!item.title) reasons.push("titill vantar");
+    if (!item.publishedAt) reasons.push("dagsetning vantar eða er ógild");
+    let parsed;
+    try { parsed = new URL(item.url); } catch { reasons.push("vefslóð er ógild"); }
+    if (parsed && (parsed.protocol !== "https:" || parsed.hostname !== "www.stjornarradid.is" || !parsed.pathname.startsWith("/efst-a-baugi/frettir/stok-frett/"))) {
+      reasons.push("vefslóð vísar ekki beint í frétt Stjórnarráðsins");
+    }
+    if (reasons.length) {
+      rejected.push({ title: item.title, url: item.url, reasons });
+      continue;
+    }
+    const key = parsed.href.replace(/\/$/, "");
+    if (seen.has(key)) {
+      duplicates.push({ title: item.title, url: item.url });
+      continue;
+    }
+    seen.add(key);
+    accepted.push(item);
+  }
+  accepted.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+  return { accepted, rejected, ignored, duplicates };
+}

--- a/test/fixtures/stjornarrad-feed.xml
+++ b/test/fixtures/stjornarrad-feed.xml
@@ -1,0 +1,18 @@
+<rss version="2.0"><channel>
+  <item>
+    <title>Framkvæmdaleyfi vegna virkjunarkosts</title>
+    <link>https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/07/Framkvaemdaleyfi/</link>
+    <description>Ráðherra kynnir breytingar vegna framkvæmdaleyfis.</description>
+    <pubDate>Fri, 07 Aug 2026 10:00:00 GMT</pubDate>
+    <lisalive:content>&lt;p&gt;Málið varðar virkjunarkost og mat á umhverfisáhrifum.&lt;/p&gt;</lisalive:content>
+  </item>
+  <item>
+    <title>Óviðkomandi frétt</title>
+    <link>https://www.stjornarradid.is/efst-a-baugi/frettir/stok-frett/2026/08/06/Onnur-frett/</link>
+    <description>Frétt um menntun.</description><pubDate>Thu, 06 Aug 2026 10:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>Náttúruvernd</title><link>https://www.stjornarradid.is/efst-a-baugi/</link>
+    <description>Náttúruvernd og líffræðileg fjölbreytni.</description><pubDate>Wed, 05 Aug 2026 10:00:00 GMT</pubDate>
+  </item>
+</channel></rss>

--- a/test/stjornarrad.test.mjs
+++ b/test/stjornarrad.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { parseStjornarradFeed, validateStjornarrad } from "../scripts/stjornarrad-lib.mjs";
+
+const fixture = await readFile(new URL("./fixtures/stjornarrad-feed.xml", import.meta.url), "utf8");
+
+test("les frétt Stjórnarráðsins og finnur efnisorð í fullum texta", () => {
+  const [item] = parseStjornarradFeed(fixture);
+  assert.equal(item.publishedAt, "2026-08-07T10:00:00.000Z");
+  assert.match(item.tags, /framkvæmdaleyfi/);
+  assert.match(item.tags, /virkjunarkostur/);
+  assert.match(item.tags, /mat á umhverfisáhrifum/);
+});
+
+test("síar frá óviðkomandi frétt og hafnar óbeinum tengli", () => {
+  const result = validateStjornarrad(parseStjornarradFeed(fixture));
+  assert.equal(result.accepted.length, 1);
+  assert.equal(result.ignored.length, 1);
+  assert.equal(result.rejected.length, 1);
+});


### PR DESCRIPTION
## Hvað breytist

- Les opinberan RSS-straum með fréttum frá öllum ráðuneytum.
- Sýnir aðeins færslur sem passa við vöktuð efnisorð um umhverfis-, skipulags- og byggingarrétt.
- Sannreynir beina fréttatengla og varðveitir eldri færslur þegar þær detta úr RSS-straumnum.
- Bætir Stjórnarráðinu við daglegu GitHub Actions-keyrsluna og viðmótið.
- Varðveitir síðustu gildu gögn við tímabundna bilun.

## Prófanir

- `node --test` — 12 prófanir standast.
- Raunkeyrsla á opinbera RSS-straumnum — 20 færslur lesnar, 3 viðeigandi og engum beinum tenglum hafnað.
- Önnur keyrsla staðfesti að engar tvítekningar myndast.

Reifanir koma úr opinberri lýsingu fréttar og eru áfram merktar sem óyfirfarnar.